### PR TITLE
Make compatible with Flux 2.0

### DIFF
--- a/src/Tags/Flux.php
+++ b/src/Tags/Flux.php
@@ -11,6 +11,11 @@ class Flux extends Tags
         return app('flux')->styles();
     }
 
+    public function appearance()
+    {
+        return app('flux')->fluxAppearance();
+    }
+
     public function scripts()
     {
         app('livewire')->forceAssetInjection();


### PR DESCRIPTION
Flux 2.0 removed `@fluxStyles` in favor of `@fluxAppearance`. This PR adds a new `{{ flux:appearance }}` tag so we can use this package with Flux 2.0. The `{{ flux:styles }}` method has been preserved so that anyone on Flux 1.0 can continue using this addon.