### PR TITLE
Fix @aware directive not working for nested Blade components

### DIFF
--- a/src/Tags/BladeHost.php
+++ b/src/Tags/BladeHost.php
@@ -1,5 +1,19 @@
 <?php
 
+/**
+ * PATCHED FILE - Do not edit vendor directly
+ *
+ * This is a patched version of stillat/antlers-components BladeHost.php
+ * Fixes: https://github.com/Stillat/antlers-components/issues/10
+ *
+ * Changes:
+ * - Added nesting depth tracking for nested Blade components
+ * - Added normalizeParams() to convert string booleans ("false" -> false)
+ * - Pre-populate component data so @aware works with parent props (variant, indicator, etc.)
+ *
+ * Remove this patch when the upstream PR is merged and package is updated.
+ */
+
 namespace Stillat\AntlersComponents\Tags;
 
 use Illuminate\View\AnonymousComponent;
@@ -15,6 +29,38 @@ class BladeHost extends Tags
 
     protected static $slots = [];
 
+    /**
+     * Track nesting depth for pre-populating component data.
+     * This is separate from the actual component stack which isn't
+     * incremented until startComponent is called.
+     */
+    protected static int $nestingDepth = 0;
+
+    /**
+     * Convert string boolean values to actual booleans.
+     * This handles cases like indicator="false" which passes the string "false".
+     *
+     * Note: :indicator="false" does NOT work because Antlers interprets "false"
+     * as a variable name lookup, not a literal. Use indicator="false" (without colon)
+     * or an Antlers variable: {{ show_indicator = false }} :indicator="show_indicator"
+     */
+    private function normalizeParams(array $params): array
+    {
+        return collect($params)->map(function ($value) {
+            if ($value === 'true') {
+                return true;
+            }
+            if ($value === 'false') {
+                return false;
+            }
+            if ($value === 'null') {
+                return null;
+            }
+
+            return $value;
+        })->all();
+    }
+
     private function makeComponentTagCompiler(): ComponentTagCompiler
     {
         /** @var BladeCompiler $bladeCompiler */
@@ -29,11 +75,12 @@ class BladeHost extends Tags
         $componentName = $this->params->get('component');
         $className = $componentTagCompiler->componentClass($componentName);
 
-        $attributes = new ComponentAttributeBag($this->params->except('component')->all());
+        $normalizedParams = $this->normalizeParams($this->params->except('component')->all());
+        $attributes = new ComponentAttributeBag($normalizedParams);
         $constructorParameters = [];
 
         $scopeData = $this->context->all();
-        $scopeData = array_merge($scopeData, $this->params->except('component')->all());
+        $scopeData = array_merge($scopeData, $normalizedParams);
 
         $isAnonymous = false;
         $anonymousViewName = $className;
@@ -50,19 +97,79 @@ class BladeHost extends Tags
         }
 
         if ($isAnonymous) {
-            $constructorParameters = array_merge($constructorParameters, ['view' => $anonymousViewName, 'data' => []]);
+            $constructorParameters = array_merge($constructorParameters, [
+                'view' => $anonymousViewName,
+                'data' => $normalizedParams,
+            ]);
         }
 
         $__env = $this->context['__env'] ?? view();
 
         $component = $className::resolve($constructorParameters + ((array) $attributes->getIterator()));
         $component->withName($componentName);
-        $__env->startComponent($component->resolveView(), $component->data());
+
+        // Pre-populate component data so nested components can access parent props via @aware
+        // This mimics what startComponent does, but without starting the output buffer yet
+        $componentData = $component->data();
+
+        // Use reflection to access protected properties
+        $factoryReflection = new ReflectionClass($__env);
+
+        // Get current stack size plus our virtual nesting depth to determine index
+        // This ensures nested BladeHost components don't overwrite parent data
+        $stackIndex = 0;
+        if ($factoryReflection->hasProperty('componentStack')) {
+            $stackProp = $factoryReflection->getProperty('componentStack');
+            $stackProp->setAccessible(true);
+            $stackIndex = count($stackProp->getValue($__env));
+        }
+        $stackIndex += self::$nestingDepth;
+        self::$nestingDepth++;
+
+        // Pre-populate componentData so @aware can find parent props
+        $existingData = [];
+        if ($factoryReflection->hasProperty('componentData')) {
+            $componentDataProp = $factoryReflection->getProperty('componentData');
+            $componentDataProp->setAccessible(true);
+            $existingData = $componentDataProp->getValue($__env);
+            $existingData[$stackIndex] = $componentData;
+            $componentDataProp->setValue($__env, $existingData);
+        }
+
+        // Set currentComponentData for @aware lookups during slot parsing
+        $previousData = [];
+        if ($factoryReflection->hasProperty('currentComponentData')) {
+            $currentDataProp = $factoryReflection->getProperty('currentComponentData');
+            $currentDataProp->setAccessible(true);
+            $previousData = $currentDataProp->getValue($__env);
+            $currentDataProp->setValue($__env, array_merge($previousData, $componentData));
+        }
+
+        // Capture slot content - nested components can now access parent data via @aware
+        $slotContent = $this->parse();
+
+        $__env->startComponent($component->resolveView(), $componentData);
         $component->withAttributes($attributes->getAttributes());
 
-        echo $this->parse();
+        echo $slotContent;
 
-        return $__env->renderComponent();
+        $result = $__env->renderComponent();
+
+        // Restore previous currentComponentData after rendering
+        if (isset($currentDataProp)) {
+            $currentDataProp->setValue($__env, $previousData);
+        }
+
+        // Clean up the pre-populated componentData after rendering
+        if (isset($componentDataProp)) {
+            unset($existingData[$stackIndex]);
+            $componentDataProp->setValue($__env, $existingData);
+        }
+
+        // Decrement nesting depth
+        self::$nestingDepth--;
+
+        return $result;
     }
 
     public function componentSlot(): void


### PR DESCRIPTION
## Summary

This CLAUDE CREATED PR fixes an issue where nested Blade components rendered through Antlers could not access parent component data via the `@aware` directive.

Relates to: #10

### The Problem

When using Flux UI components (or any nested Blade components) in Antlers templates, child components cannot access parent props via `@aware`. For example:

```antlers
<flux:radio.group variant="cards" indicator="false">
    <flux:radio label="Option 1" />  {{-- Cannot access variant or indicator --}}
</flux:radio.group>
```

The `<flux:radio>` components use `@aware(['variant', 'indicator'])` to inherit these props from the parent group, but this wasn't working because component data wasn't available during slot parsing.

### The Fix

- **Pre-populate component data**: Before parsing slot content, we now pre-populate the View Factory's `componentData` and `currentComponentData` properties so that `@aware` can find parent props
- **Nesting depth tracking**: Added a static `$nestingDepth` counter to properly manage the component stack index when multiple `BladeHost` components are nested
- **String boolean normalization**: Added `normalizeParams()` to convert string values like `"false"` to actual booleans, since Antlers passes `indicator="false"` as a string
- **AnonymousComponent data fix**: Fixed passing `'data' => []` to anonymous components - now passes actual props

### Testing

Tested with:
- Flux UI radio groups with `variant="cards"` and `indicator="false"`
- Multiple levels of nested Blade components
- Both class-based and anonymous Blade components

All scenarios now correctly inherit parent component data via `@aware`.

Again, this is a Claude PR, it works as far as I have been able to test using flux but I'm unsure of what all it may break elsewhere. Use it as a place to start.