### PR TITLE
Guard against null content in preparse callback

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,6 +25,10 @@ class ServiceProvider extends AddonServiceProvider
     {
         $this->app->resolving(RuntimeParser::class, function (RuntimeParser $parser) {
             $parser->preparse(function ($content) {
+                if (! is_string($content)) {
+                    return $content;
+                }
+
                 return (new AntlersCompiler)->compile($content);
             });
         });


### PR DESCRIPTION
## Problem

When Statamic passes `null` to the preparse callback — for example, when a tag like `{{ seo_pro:meta }}` returns no value on a 404 page — the `AntlersCompiler::compile()` method throws a `TypeError` due to its `string` type hint:

```
Stillat\AntlersComponents\AntlersCompiler::compile(): Argument #1 ($content) must be of type string, null given
```

## Fix

Added a guard in the `ServiceProvider` preparse callback to return non-string values unchanged, allowing the runtime to handle them as it normally would.

## Test plan

- [ ] Verify pages with tags that can return `null` (e.g. on 404 pages) no longer throw a `TypeError`
- [ ] Verify normal component compilation still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)